### PR TITLE
Updated federal subdivisions of Nepal with new provinces

### DIFF
--- a/lib/countries/data/subdivisions/NP.yaml
+++ b/lib/countries/data/subdivisions/NP.yaml
@@ -797,78 +797,115 @@ NA:
   comments:
   type: zone
 P1:
-  name: Province 1
+  name: Koshi Province
   code: P1
-  unofficial_names:
+  unofficial_names: [Koshi]
   geo:
+    latitude: 27.226594
+    longitude: 87.134487
+    min_latitude: 26.3473741
+    min_longitude: 86.5015001
+    max_latitude: 28.346008
+    max_longitude: 88.2018297
   translations:
-    en: Province 1
+    en: Koshi Province
+    ne: कोशी प्रदेश
   comments:
   type: province
 P2:
-  name: Province 2
+  name: Madhesh Province
   code: P2
-  unofficial_names:
+  unofficial_names: [Madhesh]
   geo:
+    latitude: 26.726581
+    longitude: 85.878288
+    min_latitude: 26.33333
+    min_longitude: 84.646302
+    max_latitude: 27.066774
+    max_longitude: 86.9457
   translations:
-    en: Province 2
+    en: Madhesh Province
+    ne: मधेश प्रदेश
   comments:
   type: province
 P3:
-  name: Province 3
+  name: Bagmati Province
   code: P3
-  unofficial_names:
+  unofficial_names: [Bagmati]
   geo:
+    latitude: 27.923508
+    longitude: 85.237122
+    min_latitude: 27.316666
+    min_longitude: 84.45634
+    max_latitude: 28.766666
+    max_longitude: 86.7
   translations:
-    en: Province 3
+    en: Bagmati Province
+    ne: बागमती प्रदेश
   comments:
   type: province
 P4:
-  name: Gandaki²
+  name: Gandaki Province
   code: P4
-  unofficial_names:
+  unofficial_names: [Gandaki]
   geo:
-    latitude: 28.394857
-    longitude: 84.12400799999999
-    min_latitude: 26.3473741
-    min_longitude: 80.05846980000001
-    max_latitude: 30.4473898
-    max_longitude: 88.20182969999999
+    latitude: 28.243426
+    longitude: 83.896532
+    min_latitude: 27.328852
+    min_longitude: 83.05629
+    max_latitude: 28.88339
+    max_longitude: 85.194321
   translations:
-    en: Gandaki²
+    en: Gandaki Province
+    ne: गण्डकी प्रदेश
   comments:
   type: province
 P5:
-  name: Province 5
+  name: Lumbini Province
   code: P5
-  unofficial_names:
+  unofficial_names: [Lumbini]
   geo:
+    latitude: 27.610125
+    longitude: 83.393209
+    min_latitude: 26.733333
+    min_longitude: 81.65873
+    max_latitude: 28.633333
+    max_longitude: 84.621499
   translations:
-    en: Province 5
+    en: Lumbini Province
+    ne: लुम्बिनी प्रदेश
   comments:
   type: province
 P6:
-  name: Karnali²
+  name: Karnali Province
   code: P6
-  unofficial_names:
+  unofficial_names: [Karnali]
   geo:
-    latitude: 28.394857
-    longitude: 84.12400799999999
-    min_latitude: 26.3473741
-    min_longitude: 80.05846980000001
-    max_latitude: 30.4473898
-    max_longitude: 88.20182969999999
+    latitude: 28.820317
+    longitude: 82.200189
+    min_latitude: 27.856192
+    min_longitude: 80.98909
+    max_latitude: 30.246437
+    max_longitude: 83.6897499
   translations:
-    en: Karnali²
+    en: Karnali Province
+    ne: कर्णाली प्रदेश
   comments:
   type: province
 P7:
-  name: Province 7
+  name: Sudurpashchim Province
   code: P7
-  unofficial_names:
+  unofficial_names: [Sudurpashchim]
   geo:
+    latitude: 29.056774
+    longitude: 81.10252
+    min_latitude: 28.2037
+    min_longitude: 80.0584698
+    max_latitude: 30.133331
+    max_longitude: 81.806982
   translations:
-    en: Province 7
+    en: Sudurpashchim Province
+    ne: सुदूरपश्चिम प्रदेश
   comments:
   type: province
 RA:


### PR DESCRIPTION
This PR updates the federal subdivisions of Nepal to include the new provinces (Koshi, Madhesh, Bagmati, Gandaki, Lumbini, Karnali and Sudurpashchim) as per the new federal structure. It also retains the previous development regions and zones for historical purposes.
Changes Made:
-  Added 7 new provinces with their official names as type: province.

-  Updated YAML structure with geo-coordinates, translations, and codes for provinces.

